### PR TITLE
Fix parallel asset compilation issue in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 
+/public/assets
 /public/packs
 /public/packs-test
 /node_modules

--- a/bin/ci
+++ b/bin/ci
@@ -2,6 +2,9 @@
 
 set -e
 
+echo "[ bin/ci ] Precompiling assets"
+bin/rails assets:precompile RAILS_ENV=test
+
 echo "[ bin/ci ] Running unit tests"
 bin/rails test
 


### PR DESCRIPTION
A flakey test turns out to have been due to asset compilation. The issue
is explained here: https://github.com/rails/webpacker/issues/2860, but
this PR addresses it by pre-compiling assets in the `bin/ci` script.

The issue could still happen locally if running `rails test` without
compiling assets.