### PR TITLE
Add admin/curator roles to User

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,8 @@
 class User < ApplicationRecord
   include Clearance::User
+
+  enum role: {
+    admin: "admin",
+    curator: "curator"
+  }
 end

--- a/db/migrate/20220116105721_add_role_to_users.rb
+++ b/db/migrate/20220116105721_add_role_to_users.rb
@@ -1,0 +1,19 @@
+class AddRoleToUsers < ActiveRecord::Migration[7.0]
+  def up
+    execute <<~SQL
+      CREATE TYPE user_role AS ENUM ('admin', 'curator');
+    SQL
+
+    add_column :users, :role, :user_role, default: "curator", null: false
+    add_index :users, :role
+  end
+
+  def down
+    remove_index :users, :role
+    remove_column :users, :role
+
+    execute <<~SQL
+      DROP TYPE user_role;
+    SQL
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -24,6 +24,16 @@ CREATE EXTENSION IF NOT EXISTS unaccent WITH SCHEMA public;
 
 
 --
+-- Name: user_role; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.user_role AS ENUM (
+    'admin',
+    'curator'
+);
+
+
+--
 -- Name: en; Type: TEXT SEARCH CONFIGURATION; Schema: public; Owner: -
 --
 
@@ -274,7 +284,8 @@ CREATE TABLE public.users (
     email character varying NOT NULL,
     encrypted_password character varying(128) NOT NULL,
     confirmation_token character varying(128),
-    remember_token character varying(128) NOT NULL
+    remember_token character varying(128) NOT NULL,
+    role public.user_role DEFAULT 'curator'::public.user_role NOT NULL
 );
 
 
@@ -556,6 +567,13 @@ CREATE INDEX index_users_on_remember_token ON public.users USING btree (remember
 
 
 --
+-- Name: index_users_on_role; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_users_on_role ON public.users USING btree (role);
+
+
+--
 -- Name: tsvector_plain_text_body_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -625,6 +643,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20211231165732'),
 ('20211231165733'),
 ('20211231165734'),
-('20220116094632');
+('20220116094632'),
+('20220116105721');
 
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,10 @@
+require "test_helper"
+
+class UserTest < ActiveSupport::TestCase
+  context "attributes" do
+    should define_enum_for(:role).with_values({
+      admin: "admin",
+      curator: "curator"
+    }).backed_by_column_of_type(:enum)
+  end
+end


### PR DESCRIPTION
Curators are users who will manage systems, admins are users who will
manage users and their roles across multiple systems.

Closes #346