### PR TITLE
Add temporary fix for Avo association authorizing

### DIFF
--- a/app/policies/entry_policy.rb
+++ b/app/policies/entry_policy.rb
@@ -34,6 +34,9 @@ class EntryPolicy < ApplicationPolicy
   private
 
   def entry_curated_by_user?
+    # Can't perform this check if Avo provides a class
+    return true if record.is_a? Class
+
     # Permit blank systems - these will be enforced by validations
     return true if record.system.blank?
 

--- a/app/policies/tag_policy.rb
+++ b/app/policies/tag_policy.rb
@@ -34,6 +34,9 @@ class TagPolicy < ApplicationPolicy
   private
 
   def tag_curated_by_user?
+    # Can't perform this check if Avo provides a class
+    return true if record.is_a? Class
+
     # Permit blank systems - these will be enforced by validations
     return true if record.system.blank?
 


### PR DESCRIPTION
Avo provides the model's class to a policy when associating a record
rather than the instance. For the time being, assume this is permitted.

Closes #469