### PR TITLE
Set variant to use based on Current.system

### DIFF
--- a/app/controllers/concerns/set_current_request_details.rb
+++ b/app/controllers/concerns/set_current_request_details.rb
@@ -4,6 +4,7 @@ module SetCurrentRequestDetails
   included do
     before_action do
       Current.system = requested_system
+      request.variant = Current.system.slug.to_sym
     end
   end
 


### PR DESCRIPTION
Allows for theming layouts, views and components based on
Current.system. Does not introduce any themed elements though.

Closes #269
