### PR TITLE
Setup and document a docker-compose.yml file

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,1 @@
+DATABASE_URL=postgres://postgres:password@localhost:5432/

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@
 
 .byebug_history
 
+# Ignore potentially sensitive local environment variables.
+.env
+
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 

--- a/README.md
+++ b/README.md
@@ -13,11 +13,24 @@ A database of Mörk Borg content. For [Liber Ludorum].
 
 - Ruby 2.7.2
 - Yarn
-- Postgres 13
-- Redis
+- Postgres 14.2
 
-For advice on setting up these dependencies, please see the
-[wiki](https://github.com/exlibrisrpg/exlibris/wiki#setting-up-dependencies).
+### Run dependencies with Docker Compose
+
+A [`docker-compose.yml`](docker-compose.yml) file is included in the repo to run
+dependencies locally. At the moment, this is just Postgres 14.2.
+
+The connection details for the Docker Compose dependencies are defined in
+[`.env.sample`](.env.sample) so copy this file to `.env` and use a tool like
+[direnv](https://direnv.net) to setup the environment variables.
+
+```sh
+cp .env.sample .env # Make a local copy of the example environment variables
+direnv allow        # Tell direnv we trust this .env file
+docker compose up   # Start the dependencies
+bin/setup -f        # Setup script with test data
+rails server        # Run the project
+```
 
 ## Setup
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,7 +31,7 @@ module Exlibris
 
     config.session_store :cookie_store, key: "_exlibrisrpg_session", domain: {
       production: ".exlibrisrpg.com",
-      development: ".exlibrisrpg.test",
+      development: [".exlibrisrpg.test", "localhost"],
       test: [".example.com", "localhost"]
     }.fetch(Rails.env.to_sym, :all), tld_length: 2
   end

--- a/config/initializers/clearance.rb
+++ b/config/initializers/clearance.rb
@@ -2,7 +2,7 @@ Clearance.configure do |config|
   config.allow_sign_up = false
   config.cookie_domain = {
     production: ".exlibrisrpg.com",
-    development: ".exlibrisrpg.test",
+    development: [".exlibrisrpg.test", "localhost"],
     test: [".example.com", "localhost"]
   }.fetch(Rails.env.to_sym, nil)
   config.mailer_sender = ENV.fetch("ADMIN_EMAIL_ADDRESS", "reply@example.com")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3.9"
+services:
+  db:
+    image: postgres:14.2-alpine
+    environment:
+      POSTGRES_PASSWORD: password
+    ports:
+      - "5432:5432"


### PR DESCRIPTION
Some users prefer running dependencies like Postgres in Docker. A
docker-compose.yml file makes it easy to ensure everyone is running the
right versions and to provide consistent configuration.

Also introduces .env.sample as a way to share non-sensitive environment
variables in the project. This just includes the `DATABASE_URL` for the
Postgres database if run on Docker.

ALso removes the reference to Redis as a dependency. This doesn't seem
to be used locally any more.

Closes #500