### PR TITLE
Setup Tailwind and apply fonts and colors

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -3,6 +3,6 @@
   "rules": {
     "string-quotes": "double",
     "selector-class-pattern": "^[a-z][a-z0-9\\:\\-]*[a-z0-9]$",
-    "custom-property-pattern": "^[a-z-]+$"
+    "custom-property-pattern": "^[\\w-]+$"
   }
 }

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -3,6 +3,6 @@
   "rules": {
     "string-quotes": "double",
     "selector-class-pattern": "^[a-z][a-z0-9\\:\\-]*[a-z0-9]$",
-    "custom-property-pattern": "^[a-z]+(-[a-z0-9]+|--[0-9][a-z0-9]*)*$"
+    "custom-property-pattern": "^[a-z-]+$"
   }
 }

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem "puma", "~> 5.6"
 gem "rails", "~> 7.0.2"
 gem "skylight"
 gem "sprockets-rails", "~> 3.4"
+gem "tailwindcss-rails", "~> 2.0"
 gem "turbo-rails"
 gem "view_component", require: "view_component/engine"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -354,6 +354,12 @@ GEM
     stimulus-rails (1.0.4)
       railties (>= 6.0.0)
     strscan (3.0.1)
+    tailwindcss-rails (2.0.8)
+      railties (>= 6.0.0)
+    tailwindcss-rails (2.0.8-arm64-darwin)
+      railties (>= 6.0.0)
+    tailwindcss-rails (2.0.8-x86_64-linux)
+      railties (>= 6.0.0)
     thor (1.2.1)
     timeout (0.2.0)
     turbo-rails (1.0.1)
@@ -420,6 +426,7 @@ DEPENDENCIES
   sprockets-rails (~> 3.4)
   stackprof
   standard
+  tailwindcss-rails (~> 2.0)
   turbo-rails
   tzinfo-data
   view_component

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,4 @@
 web: bin/rails server -p 3000
-css: yarn build:css --watch
+css-sass: yarn build:css --watch
 js: yarn build --watch
+css-tailwind: bin/rails tailwindcss:watch

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,4 @@
+//= link_tree ../stylesheets/themes
 //= link_tree ../builds
 //= link_tree ../favicons
 //= link_tree ../fonts

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,0 +1,13 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  button,
+  input,
+  optgroup,
+  select,
+  textarea {
+    color: text;
+  }
+}

--- a/app/assets/stylesheets/base/_variables.scss
+++ b/app/assets/stylesheets/base/_variables.scss
@@ -13,25 +13,6 @@ $color-map: (
   yellow-translucent: $yellow-translucent,
   none: none
 );
-$font-sans-serif: -apple-system,
-  blinkmacsystemfont,
-  "avenir next",
-  avenir,
-  "helvetica neue",
-  helvetica,
-  ubuntu,
-  roboto,
-  noto,
-  "segoe ui",
-  arial,
-  sans-serif;
-$font-palatino: palatino, "Palatino Linotype", "Palatino LT STD", "Book Antiqua", times, "Times New Roman", serif;
-$font-map: (
-  sans-serif: $font-sans-serif,
-  palatino: $font-palatino,
-  unifraktur: "UnifrakturCook",
-  plex-mono: "IBM Plex Mono"
-);
 $sizing-map: (
   -2: var(--step--2),
   -1: var(--step--1),

--- a/app/assets/stylesheets/themes/default.css
+++ b/app/assets/stylesheets/themes/default.css
@@ -1,0 +1,26 @@
+:root {
+  --font-family--brand:
+    palatino,
+    "Palatino Linotype",
+    "Palatino LT STD",
+    "Book Antiqua",
+    times,
+    "Times New Roman",
+    serif;
+  --font-family--body:
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    blinkmacsystemfont,
+    "Segoe UI",
+    roboto,
+    "Helvetica Neue",
+    arial,
+    "Noto Sans",
+    sans-serif,
+    "Apple Color Emoji",
+    "Segoe UI Emoji",
+    "Segoe UI Symbol",
+    "Noto Color Emoji";
+  --font-family--display: var(--font-family--body);
+}

--- a/app/assets/stylesheets/themes/default.css
+++ b/app/assets/stylesheets/themes/default.css
@@ -1,4 +1,56 @@
 :root {
+  /* colors */
+
+  /**
+   * Colors are defined as raw values for a hsl() function so that they can be
+   * merged with an opacity by tailwindcss. They are defined with a scale from 1
+   * to 12 based on Radix Colors:
+   * https://www.radix-ui.com/docs/colors/palette-composition/understanding-the-scale
+   */
+
+  /* colors.accent */
+  --color--accent-1: 116deg 50% 98.9%;
+  --color--accent-2: 120deg 60% 97.1%;
+  --color--accent-3: 120deg 53.6% 94.8%;
+  --color--accent-4: 121deg 47.5% 91.4%;
+  --color--accent-5: 122deg 42.6% 86.5%;
+  --color--accent-6: 124deg 39% 79.7%;
+  --color--accent-7: 126deg 37.1% 70.2%;
+  --color--accent-8: 131deg 38.1% 56.3%;
+  --color--accent-9: 131deg 41% 46.5%;
+  --color--accent-10: 132deg 43.1% 42.2%;
+  --color--accent-11: 133deg 50% 32.5%;
+  --color--accent-12: 130deg 30% 14.9%;
+
+  /* colors.primary */
+  --color--primary-1: 110deg 20% 99%;
+  --color--primary-2: 120deg 16.7% 97.6%;
+  --color--primary-3: 119deg 10.1% 95.2%;
+  --color--primary-4: 118deg 8.1% 93%;
+  --color--primary-5: 117deg 7.1% 90.8%;
+  --color--primary-6: 115deg 6.4% 88.5%;
+  --color--primary-7: 114deg 5.9% 85.4%;
+  --color--primary-8: 110deg 5.2% 77.3%;
+  --color--primary-9: 110deg 3.5% 55.5%;
+  --color--primary-10: 111deg 2.8% 51.7%;
+  --color--primary-11: 110deg 3% 43%;
+  --color--primary-12: 110deg 25% 9.5%;
+
+  /* colors.secondary */
+  --color--secondary-1: 116deg 50% 98.9%;
+  --color--secondary-2: 120deg 60% 97.1%;
+  --color--secondary-3: 120deg 53.6% 94.8%;
+  --color--secondary-4: 121deg 47.5% 91.4%;
+  --color--secondary-5: 122deg 42.6% 86.5%;
+  --color--secondary-6: 124deg 39% 79.7%;
+  --color--secondary-7: 126deg 37.1% 70.2%;
+  --color--secondary-8: 131deg 38.1% 56.3%;
+  --color--secondary-9: 131deg 41% 46.5%;
+  --color--secondary-10: 132deg 43.1% 42.2%;
+  --color--secondary-11: 133deg 50% 32.5%;
+  --color--secondary-12: 130deg 30% 14.9%;
+
+  /* fontFamily */
   --font-family--brand:
     palatino,
     "Palatino Linotype",

--- a/app/assets/stylesheets/themes/morkborg.css
+++ b/app/assets/stylesheets/themes/morkborg.css
@@ -1,4 +1,58 @@
 :root {
+  /* colors */
+
+  --morkborg-yellow: 55deg 100% 50%;
+  --morkborg-black: 0deg 0% 0%;
+  --morkborg-white: 0deg 0% 100%;
+
+  /**
+   * The Mörk Borg theme uses a very simplified set of colors as it
+   * predominantly sticks to black, white and yellow.
+   */
+
+  /* colors.accent */
+  --color--accent-1: var(--morkborg-yellow);
+  --color--accent-2: var(--morkborg-yellow);
+  --color--accent-3: var(--morkborg-yellow);
+  --color--accent-4: var(--morkborg-yellow);
+  --color--accent-5: var(--morkborg-yellow);
+  --color--accent-6: var(--morkborg-yellow);
+  --color--accent-7: var(--morkborg-yellow);
+  --color--accent-8: var(--morkborg-yellow);
+  --color--accent-9: var(--morkborg-yellow);
+  --color--accent-10: var(--morkborg-yellow);
+  --color--accent-11: var(--morkborg-black);
+  --color--accent-12: var(--morkborg-black);
+
+  /* colors.primary */
+  --color--primary-1: var(--morkborg-white);
+  --color--primary-2: var(--morkborg-white);
+  --color--primary-3: var(--morkborg-white);
+  --color--primary-4: var(--morkborg-white);
+  --color--primary-5: var(--morkborg-white);
+  --color--primary-6: var(--morkborg-white);
+  --color--primary-7: var(--morkborg-white);
+  --color--primary-8: var(--morkborg-white);
+  --color--primary-9: var(--morkborg-white);
+  --color--primary-10: var(--morkborg-white);
+  --color--primary-11: var(--morkborg-black);
+  --color--primary-12: var(--morkborg-black);
+
+  /* colors.secondary */
+  --color--secondary-1: var(--morkborg-black);
+  --color--secondary-2: var(--morkborg-black);
+  --color--secondary-3: var(--morkborg-black);
+  --color--secondary-4: var(--morkborg-black);
+  --color--secondary-5: var(--morkborg-black);
+  --color--secondary-6: var(--morkborg-black);
+  --color--secondary-7: var(--morkborg-black);
+  --color--secondary-8: var(--morkborg-black);
+  --color--secondary-9: var(--morkborg-black);
+  --color--secondary-10: var(--morkborg-black);
+  --color--secondary-11: var(--morkborg-white);
+  --color--secondary-12: var(--morkborg-white);
+
+  /* fontFamily */
   --font-family--brand:
     palatino,
     "Palatino Linotype",

--- a/app/assets/stylesheets/themes/morkborg.css
+++ b/app/assets/stylesheets/themes/morkborg.css
@@ -1,0 +1,13 @@
+:root {
+  --font-family--brand:
+    palatino,
+    "Palatino Linotype",
+    "Palatino LT STD",
+    "Book Antiqua",
+    times,
+    "Times New Roman",
+    serif;
+  --font-family--body: "IBM Plex Mono";
+  --font-family--display: "UnifrakturCook";
+  --tw-ring-offset-shadow: none;
+}

--- a/app/assets/stylesheets/utilities/_color.scss
+++ b/app/assets/stylesheets/utilities/_color.scss
@@ -1,6 +1,4 @@
 $color-rules: (
-  c: color,
-  bg: background-color,
   highlight: --color-highlight
 );
 

--- a/app/assets/stylesheets/utilities/_typography.scss
+++ b/app/assets/stylesheets/utilities/_typography.scss
@@ -1,9 +1,3 @@
-@each $name, $family in $font-map {
-  .#{$name} {
-    font-family: $family;
-  }
-}
-
 .measure-small {
   --measure: 33ch;
 }

--- a/app/components/entry_component.html.erb
+++ b/app/components/entry_component.html.erb
@@ -1,4 +1,4 @@
-<div id="<%= dom_id entry %>" class="with-sidebar | plex-mono">
+<div id="<%= dom_id entry %>" class="with-sidebar | tw-font-body">
   <div>
     <div style="width: max(25%, 16rem)">
       <% if entry.cover.attached? %>

--- a/app/components/layout/header/search_component.html.erb
+++ b/app/components/layout/header/search_component.html.erb
@@ -1,4 +1,4 @@
-<nav id="nav-search" class="cluster | cluster-baseline cluster-grow plex-mono" style="min-width: 30%;" data-turbo-permanent>
+<nav id="nav-search" class="cluster | cluster-baseline cluster-grow tw-font-body" style="min-width: 30%;" data-turbo-permanent>
   <div>
     <%= form_with model: @search, url: search_path, method: :get, class: "search | highlight-white" do |form| %>
       <div class="search--field with-icon" data-controller="highlight">

--- a/app/controllers/component_previews_controller.rb
+++ b/app/controllers/component_previews_controller.rb
@@ -1,0 +1,17 @@
+class ComponentPreviewsController < ViewComponentsController
+  include SetCurrentRequestDetails
+
+  # Copied from lookbook so we can set appropriate variant
+  # https://github.com/allmarkedup/lookbook/blob/v0.6.1/lib/lookbook/preview_controller.rb#L17-L20
+  def render_in_layout_to_string(template, locals, layout = nil)
+    set_current_request_details
+
+    append_view_path Lookbook::Engine.root.join("app/views")
+    render_to_string template, locals: locals, **determine_layout(layout)
+  end
+
+  def current_user
+    # Any present user allows previewing from any subdomain
+    true
+  end
+end

--- a/app/controllers/concerns/set_current_request_details.rb
+++ b/app/controllers/concerns/set_current_request_details.rb
@@ -2,13 +2,15 @@ module SetCurrentRequestDetails
   extend ActiveSupport::Concern
 
   included do
-    before_action do
-      Current.system = requested_system
-      request.variant = Current.system.slug.to_sym
-    end
+    before_action :set_current_request_details
   end
 
   private
+
+  def set_current_request_details
+    Current.system = requested_system
+    request.variant = Current.system.slug.to_sym
+  end
 
   def requested_system
     scope = current_user.present? ? System.all : System.live

--- a/app/views/application/_announcement.html+mork-borg.erb
+++ b/app/views/application/_announcement.html+mork-borg.erb
@@ -1,0 +1,5 @@
+<a href="https://www.patreon.com/exlibrismorkborg" class="announcement | tw-bg-secondary-1 tw-text-accent-1 hover:tw-bg-accent-1 hover:tw-text-accent-12">
+  <div class="container | centre | align-center p-s pl-l pr-l">
+    Support Ex Libris Mörk Borg on Patreon
+  </div>
+</a>

--- a/app/views/application/_announcement.html.erb
+++ b/app/views/application/_announcement.html.erb
@@ -1,5 +1,0 @@
-<a href="https://www.patreon.com/exlibrismorkborg" class="announcement | c-yellow bg-black hover-c-black hover-bg-yellow">
-  <div class="container | centre | align-center p-s pl-l pr-l">
-    Support Ex Libris Mörk Borg on Patreon
-  </div>
-</a>

--- a/app/views/dashboards/show.html+mork-borg.erb
+++ b/app/views/dashboards/show.html+mork-borg.erb
@@ -1,0 +1,26 @@
+<% content_for(:pre_header) do %>
+  <div class="dashboard-cover" data-controller="scroll-progress" data-action="resize@window->scroll-progress#resize">
+    <div class="dashboard-cover--image-container tw-bg-secondary-1">
+      <%= image_tag "exlibris_yellow.jpg", class: "dashboard-cover--image" %>
+
+      <div class="dashboard-cover--please-scroll | cluster cluster-center m-s highlight-white">
+        <div>
+          <div>
+            <span data-controller="highlight"><%= t(".scroll_down") %></span>
+          </div>
+          <%= image_tag "potato_borg.png" %>
+        </div>
+      </div>
+    </div>
+
+    <div class="dashboard-cover--content | container stack centre | p-s tw-font-brand highlight-black tw-text-secondary-12">
+      <h1 class="size-4" data-controller="highlight"><span class="p-xs"><%= t ".title" %></span></h1>
+
+      <div class="size-2 mw-measure measure-small" data-controller="highlight">
+        <p><span class="inline-block p-xs"><%= t ".subtitle" %></span></p>
+      </div>
+    </div>
+  </div>
+<% end %>
+
+<%= render template: "dashboards/show", variants: ["default"] %>

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -1,28 +1,3 @@
-<% content_for(:pre_header) do %>
-  <div class="dashboard-cover" data-controller="scroll-progress" data-action="resize@window->scroll-progress#resize">
-    <div class="dashboard-cover--image-container">
-      <%= image_tag "exlibris_yellow.jpg", class: "dashboard-cover--image" %>
-
-      <div class="dashboard-cover--please-scroll | cluster cluster-center m-s highlight-white">
-        <div>
-          <div>
-            <span data-controller="highlight"><%= t(".scroll_down") %></span>
-          </div>
-          <%= image_tag "potato_borg.png" %>
-        </div>
-      </div>
-    </div>
-
-    <div class="dashboard-cover--content | container stack centre | p-s tw-font-brand highlight-black c-white">
-      <h1 class="size-4" data-controller="highlight"><span class="p-xs"><%= t ".title" %></span></h1>
-
-      <div class="size-2 mw-measure measure-small" data-controller="highlight">
-        <p><span class="inline-block p-xs"><%= t ".subtitle" %></span></p>
-      </div>
-    </div>
-  </div>
-<% end %>
-
 <div class="stack | stack-3xl">
   <div class="stack | stack-m align-center">
     <h2 class="tw-font-display size-5"><%= t ".categories_heading" %></h2>

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -13,7 +13,7 @@
       </div>
     </div>
 
-    <div class="dashboard-cover--content | container stack centre | p-s palatino highlight-black c-white">
+    <div class="dashboard-cover--content | container stack centre | p-s tw-font-brand highlight-black c-white">
       <h1 class="size-4" data-controller="highlight"><span class="p-xs"><%= t ".title" %></span></h1>
 
       <div class="size-2 mw-measure measure-small" data-controller="highlight">
@@ -25,9 +25,9 @@
 
 <div class="stack | stack-3xl">
   <div class="stack | stack-m align-center">
-    <h2 class="unifraktur size-5"><%= t ".categories_heading" %></h2>
+    <h2 class="tw-font-display size-5"><%= t ".categories_heading" %></h2>
 
-    <dl class="switcher | plex-mono">
+    <dl class="switcher | tw-font-body">
       <% @dashboard.categories.in_groups(2, false) do |category_group| %>
         <div class="stack | stack-xs">
           <% category_group.each do |category| %>
@@ -42,8 +42,8 @@
   </div>
 
   <div class="stack | stack-m align-center">
-    <h2 class="unifraktur size-5"><%= t ".latest_entries_heading" %></h2>
-    <p class="plex-mono"><%= t ".latest_entries_subheading_html" %></p>
+    <h2 class="tw-font-display size-5"><%= t ".latest_entries_heading" %></h2>
+    <p class="tw-font-body"><%= t ".latest_entries_subheading_html" %></p>
 
     <div class="reel" data-controller="reel">
       <%= render EntryTileComponent.with_collection(@dashboard.recently_created_entries) %>

--- a/app/views/layouts/_head.html+mork-borg.erb
+++ b/app/views/layouts/_head.html+mork-borg.erb
@@ -1,0 +1,7 @@
+<%= stylesheet_link_tag "themes/morkborg", media: "all", "data-turbo-track": "reload" %>
+
+<%= preload_link_tag "UnifrakturCook-Bold.ttf" %>
+<%= preload_link_tag "IBMPlexMono-Regular.ttf" %>
+<%= preload_link_tag "IBMPlexMono-Italic.ttf" %>
+<%= preload_link_tag "IBMPlexMono-Bold.ttf" %>
+<%= preload_link_tag "IBMPlexMono-BoldItalic.ttf" %>

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -1,0 +1,1 @@
+<%= stylesheet_link_tag "themes/default", media: "all", "data-turbo-track": "reload" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,13 +5,11 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "application", media: "all", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
-    <%= preload_link_tag "UnifrakturCook-Bold.ttf" %>
-    <%= preload_link_tag "IBMPlexMono-Regular.ttf" %>
-    <%= preload_link_tag "IBMPlexMono-Italic.ttf" %>
-    <%= preload_link_tag "IBMPlexMono-Bold.ttf" %>
-    <%= preload_link_tag "IBMPlexMono-BoldItalic.ttf" %>
+
+    <%= render partial: "layouts/head" %>
 
     <%= render partial: "layouts/favicon" %>
     <%= render MetaTagsComponent.new(target: @social_focus, title: content_for(:title), url: request.original_url) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
     <% end %>
   </head>
 
-  <body class="fill | bg-black plex-mono">
+  <body class="fill | bg-black tw-font-body">
     <%= render partial: "announcement" %>
 
     <% if content_for?(:pre_header) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,14 +19,14 @@
     <% end %>
   </head>
 
-  <body class="fill | bg-black tw-font-body">
+  <body class="fill | tw-bg-primary-1 tw-text-primary-11 tw-font-body">
     <%= render partial: "announcement" %>
 
     <% if content_for?(:pre_header) %>
       <%= yield(:pre_header) %>
     <% end %>
 
-    <div class="fill | fill-with | bg-white">
+    <div class="fill | fill-with | tw-bg-primary-1">
       <header id="content">
         <%= yield :header %>
       </header>

--- a/app/views/layouts/component_preview.html.erb
+++ b/app/views/layouts/component_preview.html.erb
@@ -5,13 +5,11 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "application", media: "all", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
-    <%= preload_link_tag "UnifrakturCook-Bold.ttf" %>
-    <%= preload_link_tag "IBMPlexMono-Regular.ttf" %>
-    <%= preload_link_tag "IBMPlexMono-Italic.ttf" %>
-    <%= preload_link_tag "IBMPlexMono-Bold.ttf" %>
-    <%= preload_link_tag "IBMPlexMono-BoldItalic.ttf" %>
+
+    <%= render partial: "layouts/head" %>
   </head>
 
   <body class="<%= params[:lookbook][:display][:body_class] %>">

--- a/app/views/layouts/public.html.erb
+++ b/app/views/layouts/public.html.erb
@@ -1,5 +1,5 @@
 <% content_for :header do %>
-  <div class="stack | p-s pl-l pr-l | bg-yellow">
+  <div class="stack | p-s pl-l pr-l | tw-bg-accent-2 tw-text-accent-12">
     <div class="container | centre cluster | cluster-space cluster-baseline">
       <div>
         <div class="cluster | cluster-baseline cluster-grow">
@@ -16,8 +16,8 @@
     </div>
   </div>
 
-  <div class="bg-black c-white">
-    <div class="container | cluster cluster-xs centre | bg-black pl-l pr-l">
+  <div class="tw-bg-secondary-2 tw-text-secondary-11">
+    <div class="container | cluster cluster-xs centre | tw-bg-secondary-2 pl-l pr-l">
       <div class="size--1 tw-font-body">
         <% Tag.categories(Current.system).each do |category| %>
           <em><%= link_to category.name, category %></em>
@@ -28,7 +28,7 @@
 <% end %>
 
 <% content_for :footer do %>
-  <div class="bg-black c-white">
+  <div class="tw-bg-secondary-2 tw-text-secondary-11">
     <div class="container | centre | p-s measure-wide tw-font-body">
       <div class="switcher size--2">
           <ul role="menu" class="stack | stack-2xs">

--- a/app/views/layouts/public.html.erb
+++ b/app/views/layouts/public.html.erb
@@ -3,7 +3,7 @@
     <div class="container | centre cluster | cluster-space cluster-baseline">
       <div>
         <div class="cluster | cluster-baseline cluster-grow">
-          <div class="palatino size-2 highlight-none">
+          <div class="tw-font-brand size-2 highlight-none">
             <%= link_to t("application.name"), root_path(anchor: "content") %>
             <small class="size--1"><%= t("application.tagline") %></small>
           </div>
@@ -16,9 +16,9 @@
     </div>
   </div>
 
-  <div class="c-white bg-black">
+  <div class="bg-black c-white">
     <div class="container | cluster cluster-xs centre | bg-black pl-l pr-l">
-      <div class="size--1 plex-mono">
+      <div class="size--1 tw-font-body">
         <% Tag.categories(Current.system).each do |category| %>
           <em><%= link_to category.name, category %></em>
         <% end %>
@@ -28,11 +28,11 @@
 <% end %>
 
 <% content_for :footer do %>
-  <div class="c-white bg-black">
-    <div class="container | centre | p-s measure-wide plex-mono">
+  <div class="bg-black c-white">
+    <div class="container | centre | p-s measure-wide tw-font-body">
       <div class="switcher size--2">
           <ul role="menu" class="stack | stack-2xs">
-            <li class="palatino size-1"><%= link_to t("application.name"), root_path(anchor: "content") %></li>
+            <li class="tw-font-brand size-1"><%= link_to t("application.name"), root_path(anchor: "content") %></li>
             <li><%= link_to t(".footer.tags_link"), tags_path %></li>
             <li><%= link_to t(".footer.search_link"), search_path %></li>
             <li><%= link_to t(".footer.credits_link"), credits_path %></li>

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title) do %><%= t(".title") %><% end %>
 
-<div class="stack | plex-mono measure mw-measure">
+<div class="stack | tw-font-body measure mw-measure">
   <%= t ".page_html" %>
 </div>

--- a/app/views/pages/credits.html.erb
+++ b/app/views/pages/credits.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:title) do %><%= t(".title") %><% end %>
 
-<div class="stack stack-l | plex-mono align-center">
-  <h1 class="unifraktur size-5"><%= t(".title") %></h1>
+<div class="stack stack-l | tw-font-body align-center">
+  <h1 class="tw-font-display size-5"><%= t(".title") %></h1>
 
   <h2>Questing Adventurer</h2>
   <ul class="credits-list" style="--columns: 1;" role="list">

--- a/app/views/searches/_form.html.erb
+++ b/app/views/searches/_form.html.erb
@@ -12,7 +12,7 @@
 
             <turbo-frame id="searchTagResults">
               <fieldset disabled style="z-index: 1;">
-                <ul role="listbox" data-combobox-target="list" class="hidden highlight-none selected-highlight-yellow c-black p-none m-none search--tag-list stack stack-2xs m-s" data-controller="highlight" data-action="combobox:stopped@document->highlight#redraw">
+                <ul role="listbox" data-combobox-target="list" class="hidden highlight-none selected-highlight-yellow tw-text-primary-11 p-none m-none search--tag-list stack stack-2xs m-s" data-controller="highlight" data-action="combobox:stopped@document->highlight#redraw">
                   <% @search.tags.each do |tag| %>
                     <%= render partial: "searches/filter_tag", locals: { tag: tag } %>
                   <% end %>
@@ -22,7 +22,7 @@
           </div>
 
           <div class="cluster">
-            <ul role="list" data-combobox-target="collection" class="search--filter-tags p-none c-black highlight-yellow">
+            <ul role="list" data-combobox-target="collection" class="search--filter-tags p-none tw-text-primary-11 highlight-yellow">
               <li class="hidden-if-only-child">Tags:</li>
               <% search.filter_tags.each do |tag| %>
                 <%= render partial: "searches/filter_tag", locals: { tag: tag } %>

--- a/app/views/searches/_form.html.erb
+++ b/app/views/searches/_form.html.erb
@@ -1,18 +1,18 @@
 <%= form_with model: search, url: search_path, method: :get, class: "search", data: { controller: "form", "form-target": "form", "form-submit-frame-value": "searchTagResults" } do |form| %>
   <div class="cluster">
-    <div class="plex-mono">
+    <div class="tw-font-body">
       <div class="cluster cluster-grow | highlight-white" style="flex: 1 0;">
         <div class="search--field with-icon" data-controller="highlight" data-action="combobox:stopped@document->highlight#redraw">
           <%= form.label :query do %>
             <%= icon_tag :search %>
           <% end %>
 
-          <div class="cluster-grow relative">
+          <div class="relative cluster-grow">
             <%= form.text_field :query, name: :query, placeholder: Search.model_name.human, autocomplete: "off", data: { "combobox-target": "input", action: "focus->combobox#start input->form#submit" } %>
 
             <turbo-frame id="searchTagResults">
               <fieldset disabled style="z-index: 1;">
-                <ul role="listbox" data-combobox-target="list" class="highlight-none selected-highlight-yellow c-black p-none m-none hidden search--tag-list stack stack-2xs m-s" data-controller="highlight" data-action="combobox:stopped@document->highlight#redraw">
+                <ul role="listbox" data-combobox-target="list" class="hidden highlight-none selected-highlight-yellow c-black p-none m-none search--tag-list stack stack-2xs m-s" data-controller="highlight" data-action="combobox:stopped@document->highlight#redraw">
                   <% @search.tags.each do |tag| %>
                     <%= render partial: "searches/filter_tag", locals: { tag: tag } %>
                   <% end %>

--- a/app/views/searches/show.html.erb
+++ b/app/views/searches/show.html.erb
@@ -1,9 +1,9 @@
 <% content_for(:title) do %><%= t(".title") %><% end %>
 
 <% content_for :banner do %>
-  <div class="c-white bg-black" data-controller="combobox" data-action="combobox-commit->combobox#add" data-combobox-hidden-class="hidden">
+  <div class="bg-black c-white" data-controller="combobox" data-action="combobox-commit->combobox#add" data-combobox-hidden-class="hidden">
     <div class="container | centre stack | align-center p-l">
-      <h1 class="unifraktur size-5"><%= t(".title") %></h1>
+      <h1 class="tw-font-display size-5"><%= t(".title") %></h1>
 
       <%= render partial: "form", locals: { search: @search } %>
     </div>
@@ -12,9 +12,9 @@
 
 <% if @search.valid? %>
   <div class="stack | stack-l">
-  <h2 class="unifraktur size-5 align-center"><%= pluralize(@search.tags.count, Tag.model_name.human) %></h2>
+  <h2 class="tw-font-display size-5 align-center"><%= pluralize(@search.tags.count, Tag.model_name.human) %></h2>
 
-  <div class="cluster | cluster-center plex-mono" data-controller="search-highlights">
+  <div class="cluster | cluster-center tw-font-body" data-controller="search-highlights">
     <div>
       <% @search.tags.each do |tag| %>
         <%= link_to search_highlight(tag.name, @search.query&.split(" ")), tag %>
@@ -22,11 +22,11 @@
     </div>
   </div>
 
-  <h2 class="unifraktur size-5 align-center"><%= pluralize(@search.entries.count, Entry.model_name.human) %></h2>
+  <h2 class="tw-font-display size-5 align-center"><%= pluralize(@search.entries.count, Entry.model_name.human) %></h2>
 
   <%= render "shared/paginate", page: @page, path: ->(next_page) {search_path(query: @search.query, page: @page.next_param)}, class: "stack | stack-l" do %>
     <% @page.records.each do |entry| %>
-      <div id="<%= dom_id entry %>" class="with-sidebar | plex-mono" data-controller="search-highlights">
+      <div id="<%= dom_id entry %>" class="with-sidebar | tw-font-body" data-controller="search-highlights">
         <div>
           <div style="width: max(25%, 16rem)">
             <% if entry.cover.attached? %>

--- a/app/views/searches/show.html.erb
+++ b/app/views/searches/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:title) do %><%= t(".title") %><% end %>
 
 <% content_for :banner do %>
-  <div class="bg-black c-white" data-controller="combobox" data-action="combobox-commit->combobox#add" data-combobox-hidden-class="hidden">
+  <div class="tw-bg-secondary-3 tw-text-secondary-12" data-controller="combobox" data-action="combobox-commit->combobox#add" data-combobox-hidden-class="hidden">
     <div class="container | centre stack | align-center p-l">
       <h1 class="tw-font-display size-5"><%= t(".title") %></h1>
 

--- a/app/views/shared/_paginate.html.erb
+++ b/app/views/shared/_paginate.html.erb
@@ -6,7 +6,7 @@
     <%= turbo_frame_tag "page_#{page.number + 1}", target: "_top", src: next_page_path, loading: "lazy", class: local_assigns[:class], style: "display: block;", data: { controller: "frame", action: "turbo:frame-load->frame#disable" } do %>
       <div class="center">
         <div class="cluster | cluster-center">
-          <div class="plex-mono">
+          <div class="tw-font-body">
             <%= tag.span t(".loading") %>
           </div>
         </div>
@@ -16,7 +16,7 @@
 
   <div class="center" data-controller="hide" data-hide-hidden-class="hidden">
     <div class="cluster | cluster-center">
-      <div class="plex-mono">
+      <div class="tw-font-body">
         <% if !page.first? %>
           <% previous_page_path = path.call(page.number - 1) %>
           <%= highlight_link_to t(".previous_page"), previous_page_path %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -86,6 +86,8 @@ Rails.application.configure do
   config.view_component.default_preview_layout = "component_preview"
 
   # Setup Lookbook:
+  # - Use local preview controller
+  config.lookbook.preview_controller = "ComponentPreviewsController"
   # - Specify default params for the preview layout
   config.lookbook.preview_display_params = {
     container: true

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -1,5 +1,22 @@
 const defaultTheme = require("tailwindcss/defaultTheme")
 
+function withOpacityValue(variable) {
+  return ({ opacityValue }) => {
+    if (opacityValue === undefined) {
+      return `hsl(var(${variable}))`
+    }
+    return `hsl(var(${variable}) / ${opacityValue})`
+  }
+}
+
+function colorDefinition(type) {
+  return Object.fromEntries(
+    Array.from(Array(13).keys())
+      .slice(1)
+      .map((i) => [i, withOpacityValue(`--color--${type}-${i}`)])
+  )
+}
+
 module.exports = {
   content: [
     "./app/components/**/*.erb",
@@ -13,7 +30,10 @@ module.exports = {
       current: "current",
       transparent: "transparent",
       black: "black",
-      white: "white"
+      white: "white",
+      accent: colorDefinition("accent"),
+      primary: colorDefinition("primary"),
+      secondary: colorDefinition("secondary")
     },
     fontFamily: {
       brand: "var(--font-family--brand)",

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -1,0 +1,37 @@
+const defaultTheme = require("tailwindcss/defaultTheme")
+
+module.exports = {
+  content: [
+    "./app/components/**/*.erb",
+    "./app/helpers/**/*.rb",
+    "./app/javascript/**/*.js",
+    "./app/views/**/*.erb"
+  ],
+  theme: {
+    colors: {
+      inherit: "inherit",
+      current: "current",
+      transparent: "transparent",
+      black: "black",
+      white: "white"
+    },
+    fontFamily: {
+      brand: "var(--font-family--brand)",
+      body: "var(--font-family--body)",
+      display: "var(--font-family--display)"
+    }
+  },
+  // Prefix all classes with tw-* for now to ensure no collisions with the
+  // original Mörk Borg design during the theme extraction process
+  prefix: "tw-",
+  plugins: [
+    require("@tailwindcss/forms")({
+      // Apply form classes manually as they are reviewed in the theme
+      // extraction process:
+      // https://github.com/tailwindlabs/tailwindcss-forms#using-classes-to-style
+      strategy: "class"
+    }),
+    require("@tailwindcss/aspect-ratio"),
+    require("@tailwindcss/typography")
+  ]
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,1 @@
+config/tailwind.config.js

--- a/test/components/previews/layout/header/search_component_preview.rb
+++ b/test/components/previews/layout/header/search_component_preview.rb
@@ -1,4 +1,4 @@
-# @display body_class "bg-yellow"
+# @display body_class "tw-bg-accent-2"
 class Layout::Header::SearchComponentPreview < ViewComponent::Preview
   # A search box which will expand to fill any available space. This search box
   # cannot currently show, add or remove filter tags - unlike the search box on


### PR DESCRIPTION
Introduce [tailwindcss-rails](https://github.com/rails/tailwindcss-rails) to generate a `tailwind.css` file for the application. This file will provide all the structural and thematic styling for the site.

The `tailwind.css` file only applies [CSS custom properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties) though - those values are provided by one of the files in `app/assets/stylesheets/themes`. This is how each theme is customised. Currently those files only provide fonts and colors.

Finally this PR also replaces all of the original font and color classes with the equivalent theme classes provided by tailwind.

Closes #505
Closes #506