### PR TITLE
Fix TagResource short_description required lambda

### DIFF
--- a/app/avo/resources/tag_resource.rb
+++ b/app/avo/resources/tag_resource.rb
@@ -15,7 +15,7 @@ class TagResource < Avo::BaseResource
       scope.first.id
     end
   end
-  field :short_description, as: :text, visible: ->(resource:) { resource.model.tag_category&.short_description_required }, required: ->(resource:) { resource.model.tag_category&.short_description_required }, hide_on: :index
+  field :short_description, as: :text, visible: ->(resource:) { resource.model.tag_category&.short_description_required }, required: -> { record.tag_category&.short_description_required }, hide_on: :index
   field :order, as: :number, sortable: true
 
   field :description, as: :trix, always_show: true, attachments_disabled: true


### PR DESCRIPTION
A `required` lambda is executed against a `ViewRecordHost` now rather
than having arguments provided. So instead of expecting a `resource`
parameter we can get the `record` directly.
