### PR TITLE
Setup filters for user roles and curations

### DIFF
--- a/app/avo/filters/user_curates_system_filter.rb
+++ b/app/avo/filters/user_curates_system_filter.rb
@@ -1,0 +1,15 @@
+class UserCuratesSystemFilter < Avo::Filters::SelectFilter
+  self.name = "Curates system"
+
+  def apply(request, query, value)
+    return query unless value.present?
+
+    query.includes(:curation_roles).where(curation_roles: {system: value}).or(query.admin)
+  end
+
+  def options
+    System
+      .select(:id, :name)
+      .each_with_object({}) { |system, options| options[system.id] = system.name }
+  end
+end

--- a/app/avo/filters/user_role_filter.rb
+++ b/app/avo/filters/user_role_filter.rb
@@ -1,0 +1,20 @@
+class UserRoleFilter < Avo::Filters::BooleanFilter
+  self.name = "Role"
+
+  def apply(request, query, values)
+    return query if values["is_admin"] && values["is_curator"]
+    if values["is_admin"]
+      query = query.admin
+    elsif values["is_curator"]
+      query = query.curator
+    end
+    query
+  end
+
+  def options
+    {
+      is_admin: "Admin",
+      is_curator: "Curator"
+    }
+  end
+end

--- a/app/avo/resources/user_resource.rb
+++ b/app/avo/resources/user_resource.rb
@@ -11,4 +11,7 @@ class UserResource < Avo::BaseResource
   field :curated_systems, as: :has_many, through: :curation_roles
 
   action ResetPassword
+
+  filter UserRoleFilter
+  filter UserCuratesSystemFilter
 end

--- a/app/models/system.rb
+++ b/app/models/system.rb
@@ -2,7 +2,7 @@ class System < ApplicationRecord
   extend FriendlyId
 
   has_many :curation_roles, dependent: :destroy
-  has_many :curators, through: :curation_roles, source: :user
+  has_many :curators, through: :curation_roles, source: :user, inverse_of: :curated_systems
   has_many :entries
   has_many :tags
   has_many :tag_categories

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   include Clearance::User
 
   has_many :curation_roles, dependent: :destroy
-  has_many :curated_systems, through: :curation_roles, source: :system
+  has_many :curated_systems, through: :curation_roles, source: :system, inverse_of: :curators
 
   enum role: {
     admin: "admin",


### PR DESCRIPTION
Allows admins to filter lists of users by their role or the systems they
are able to curate.
