### PR TITLE
Fix category tags for entries

### DIFF
--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -34,7 +34,7 @@ class Entry < ApplicationRecord
   scope :with_tags, ->(filter_tag_ids) { where(id: Entry.joins(:entries_tags).where(entries_tags: {tag_id: filter_tag_ids}).group(:id).having("COUNT(entries.*) = ?", filter_tag_ids.size)) }
 
   def category_tags
-    tags.with_includes.where(tag_category: TagCategory.find_by(name: "Categories"))
+    tags.with_includes.where(tag_category: TagCategory.find_by(name: "Categories", system: system))
   end
 
   def to_meta_tags

--- a/test/models/entry_test.rb
+++ b/test/models/entry_test.rb
@@ -25,6 +25,13 @@ class EntryTest < ActiveSupport::TestCase
 
   should accept_nested_attributes_for(:links).allow_destroy(true)
 
+  context ".category_tags" do
+    should "return tags under the 'Categories' Tag Category for the same system" do
+      assert_includes tags(:mausritter_rules).entries.first.category_tags, tags(:mausritter_rules)
+      assert_includes tags(:mork_borg_rules).entries.first.category_tags, tags(:mork_borg_rules)
+    end
+  end
+
   context ".containing" do
     should "match on name and description" do
       results = Entry.containing("eat or feat")


### PR DESCRIPTION
Entries were looking up category tags based on the 'Categories' name.
This meant that the returned tag category might be for a different
system. As none of the entry's tags would be part of another system's
categories, the category tags method would always return an empty
collection.

Closes #757
