### PR TITLE
Additional styling and content for Death in Space system.

### DIFF
--- a/app/assets/stylesheets/themes/deathinspace.css
+++ b/app/assets/stylesheets/themes/deathinspace.css
@@ -2,6 +2,7 @@
   --dis-black: 0deg 0% 0%;
   --dis-red: 0deg 100% 30%;
   --dis-white: 0deg 0% 100%;
+  --dis-gray: 0deg 0% 60%;
 
   /* search bar bg, search term match fg */
   --color--accent-1: var(--dis-red);
@@ -12,9 +13,9 @@
   /* each latest item bg */
   --color--accent-4: var(--dis-black);
   /* button border */
-  --color--accent-6: var(--dis-white);
+  --color--accent-6: var(--dis-red);
   /* button hover border */
-  --color--accent-7: var(--dis-white);
+  --color--accent-7: var(--dis-red);
   /* search term match bg */
   --color--accent-9: var(--dis-black);
   /* search bar text */
@@ -22,7 +23,7 @@
   /* header text, search bar magnifying glass icon */
   --color--accent-12: var(--dis-white);
 
-  /* categories and latest additions title text */
+  /* main text, including entry content and categories /latest additions title text */
   --color--main-11: var(--dis-white);
 
   /* colors.primary; main content bg */
@@ -38,4 +39,20 @@
   --font-family--body: "IBM Plex Mono";
   --font-family--brand: "IBM Plex Mono";
   --font-family--display: "IBM Plex Mono";
+}
+
+h1 {
+  font-weight: 400;
+  text-transform: uppercase;
+}
+
+h2 {
+  font-weight: 400;
+  text-transform: uppercase;
+}
+
+.tw-button {
+  border-radius: 0%;
+  border-color: hsl(var(--dis-red));
+  text-transform: uppercase;
 }

--- a/app/assets/stylesheets/themes/deathinspace.css
+++ b/app/assets/stylesheets/themes/deathinspace.css
@@ -40,12 +40,7 @@
   --font-family--display: "IBM Plex Mono";
 }
 
-h1 {
-  font-weight: 400;
-  text-transform: uppercase;
-}
-
-h2 {
+h1, h2 {
   font-weight: 400;
   text-transform: uppercase;
 }

--- a/app/assets/stylesheets/themes/deathinspace.css
+++ b/app/assets/stylesheets/themes/deathinspace.css
@@ -2,8 +2,7 @@
   --dis-black: 0deg 0% 0%;
   --dis-red: 0deg 100% 30%;
   --dis-white: 0deg 0% 100%;
-  --dis-gray: 0deg 0% 60%;
-
+  
   /* search bar bg, search term match fg */
   --color--accent-1: var(--dis-red);
   /* header bg */

--- a/app/components/dashboard/categories_component.html+deathinspace.erb
+++ b/app/components/dashboard/categories_component.html+deathinspace.erb
@@ -1,0 +1,16 @@
+<div class="tw-flex tw-flex-col tw-gap-6 tw-text-center">
+  <h2 class="tw-font-display tw-text-2xl tw-text-accent-10"><%= t ".heading" %></h2>
+
+  <dl class="switcher | tw-font-body">
+    <% categories.in_groups(2, false) do |category_group| %>
+      <div class="tw-flex tw-flex-col tw-gap-3">
+        <% category_group.each do |category| %>
+          <div>
+            <dt><%= link_to category.name, category, data: { } %></dt>
+            <dd><%= category.short_description %></dd>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+  </dl>
+</div>

--- a/app/components/dashboard/latest_entries_component.html+deathinspace.erb
+++ b/app/components/dashboard/latest_entries_component.html+deathinspace.erb
@@ -1,0 +1,11 @@
+<div class="tw-flex tw-flex-col tw-gap-6">
+  <h2 class="tw-font-display tw-text-2xl"><%= t ".heading" %></h2>
+
+  <div class="tw-flex tw-gap-3 tw-bg-accent-3 tw-p-3 tw-overflow-x-auto tw-overflow-y-hidden tw-scroll-pl-3 tw-scroll-pr-3 tw-snap-x tw-scroll-smooth">
+    <% @entries.each do |entry| %>
+      <div class="tw-snap-start last:tw-pr-3">
+        <%= render EntryTileComponent.new(entry: entry) %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/layouts/system.html+deathinspace.erb
+++ b/app/views/layouts/system.html+deathinspace.erb
@@ -52,7 +52,7 @@
         <div class="tw-container tw-mx-auto tw-p-4 tw-font-body">
           <div class="switcher tw-text-xs tw-leading-relaxed">
             <ul role="menu" class="tw-flex tw-flex-col tw-gap-2">
-              <li class="tw-font-brand tw-text-xl tw-font-extrabold" style="text-transform: uppercase;"><%= link_to Current.system.full_name, dashboard_path(anchor: "content") %></li>
+              <li class="tw-font-brand tw-text-xl tw-font-extrabold tw-uppercase"><%= link_to Current.system.full_name, dashboard_path(anchor: "content") %></li>
               <li><%= link_to t(".footer.tags_link"), tags_path %></li>
               <li><%= link_to t(".footer.search_link"), search_path %></li>
               <li><%= link_to t(".footer.credits_link"), credits_path %></li>

--- a/app/views/layouts/system.html+deathinspace.erb
+++ b/app/views/layouts/system.html+deathinspace.erb
@@ -1,0 +1,72 @@
+<% content_for(:body_class) do %>fill | tw-bg-primary-1 tw-text-main-11 tw-font-body<% end %>
+
+<% content_for :body do %>
+  <%= render partial: "announcement" %>
+
+  <% if content_for?(:pre_header) %>
+    <%= yield(:pre_header) %>
+  <% end %>
+
+  <div class="fill | fill-with | tw-bg-primary-1">
+    <header id="content">
+      <div class="tw-bg-accent-2 tw-text-accent-12">
+        <div class="tw-container tw-mx-auto tw-p-4 tw-flex tw-gap-4 tw-items-center tw-justify-between tw-flex-wrap">
+          <div class="tw-flex tw-gap-4 tw-flex-grow tw-items-baseline tw-justify-center tw-font-brand tw-flex-wrap highlight-none">
+            <%= link_to Current.system.full_name, dashboard_path(anchor: "content"), class: "tw-text-3xl tw-font-extrabold tw-text-accent-1", style: "text-transform: uppercase;" %>
+            <small class="tw-text-base"><%= Current.system.tagline %></small>
+          </div>
+
+          <div class="tw-w-4/12 tw-flex-grow">
+            <% if @search.blank? %>
+              <%= render Layout::Header::SearchComponent.new(search: @search) %>
+            <% end %>
+          </div>
+        </div>
+      </div>
+
+      <%= render Layout::Header::SecondaryNavComponent.new(links: Tag.categories(Current.system).map { |category| { label: category.name, path: url_for(category) } }) %>
+    </header>
+
+    <main class="fill-with">
+      <% if content_for?(:banner) %>
+        <%= content_for :banner %>
+      <% end %>
+
+      <div class="tw-container tw-mx-auto tw-p-4">
+        <div class="tw-flex tw-flex-col tw-gap-6">
+          <% if flash.any? %>
+            <div id="flash">
+              <% flash.each do |key, value| %>
+                <div class="flash <%= key %>"><%= value %></div>
+              <% end %>
+            </div>
+          <% end %>
+
+          <%= yield %>
+        </div>
+      </div>
+    </main>
+
+    <footer>
+      <div class="tw-bg-secondary-2 tw-text-secondary-11">
+        <div class="tw-container tw-mx-auto tw-p-4 tw-font-body">
+          <div class="switcher tw-text-xs tw-leading-relaxed">
+            <ul role="menu" class="tw-flex tw-flex-col tw-gap-2">
+              <li class="tw-font-brand tw-text-xl tw-font-extrabold" style="text-transform: uppercase;"><%= link_to Current.system.full_name, dashboard_path(anchor: "content") %></li>
+              <li><%= link_to t(".footer.tags_link"), tags_path %></li>
+              <li><%= link_to t(".footer.search_link"), search_path %></li>
+              <li><%= link_to t(".footer.credits_link"), credits_path %></li>
+              <li><%= link_to t(".footer.about_link"), about_path %></li>
+            </ul>
+
+            <div class="tw-flex tw-flex-col tw-gap-2 tw-max-w-prose">
+              <%= Current.system.footer %>
+            </div>
+          </div>
+        </div>
+      </div>
+    </footer>
+  </div>
+<% end %>
+
+<%= render template: "layouts/application" %>

--- a/app/views/pages/about.html+deathinspace.erb
+++ b/app/views/pages/about.html+deathinspace.erb
@@ -1,6 +1,6 @@
 <% content_for(:title) do %><%= t(".title") %><% end %>
 
 <div class="tw-flex tw-flex-col tw-gap-6 tw-font-body tw-max-w-prose">
-  <%= t ".death_in_space_html" %>
+  <%= t ".deathinspace_page_html" %>
 </div>
   

--- a/app/views/pages/about.html+deathinspace.erb
+++ b/app/views/pages/about.html+deathinspace.erb
@@ -1,0 +1,6 @@
+<% content_for(:title) do %><%= t(".title") %><% end %>
+
+<div class="tw-flex tw-flex-col tw-gap-6 tw-font-body tw-max-w-prose">
+  <%= t ".death_in_space_html" %>
+</div>
+  

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -76,6 +76,13 @@ en:
         <hr>
         <p>Unless otherwise noted, the third-party products presented here are independent productions by their respective authors/publishers and are not affiliated with Ockult Örtmästare Games or Stockholm Kartell. They are published under the MÖRK BORG Third Party License.</p>
         <p>MÖRK BORG is copyright Ockult Örtmästare Games and Stockholm Kartell.</p>
+      death_in_space_html: |
+        <h1>About ELDIS</h1>
+        <p>EX LIBRIS DEATH IN SPACE is a directory of official, semi-official, and third-party content for the DEATH IN SPACE RPG. This resource is meant to raise creators’ visibility in the community and help players & GMs discover new content to use in their games.</p>
+        <p>If you know of missing content or have published something of your own, drop by the <a href="https://discord.gg/Psqc7p4x4p" class="tw-underline">DEATH IN SPACE discord</a> and post it in the <code>#stuff-for-death</code> channel.</p>
+        <hr>
+        <p>Unless otherwise noted, the third-party products presented here are independent productions by their respective authors/publishers and are not affiliated with Stockholm Kartell.</p>
+        <p>DEATH IN SPACE is © Stockholm Kartell and/or other authors.</p>
     credits:
       title: Credits
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -76,7 +76,7 @@ en:
         <hr>
         <p>Unless otherwise noted, the third-party products presented here are independent productions by their respective authors/publishers and are not affiliated with Ockult Örtmästare Games or Stockholm Kartell. They are published under the MÖRK BORG Third Party License.</p>
         <p>MÖRK BORG is copyright Ockult Örtmästare Games and Stockholm Kartell.</p>
-      death_in_space_html: |
+      deathinspace_page_html: |
         <h1>About ELDIS</h1>
         <p>EX LIBRIS DEATH IN SPACE is a directory of official, semi-official, and third-party content for the DEATH IN SPACE RPG. This resource is meant to raise creators’ visibility in the community and help players & GMs discover new content to use in their games.</p>
         <p>If you know of missing content or have published something of your own, drop by the <a href="https://discord.gg/Psqc7p4x4p" class="tw-underline">DEATH IN SPACE discord</a> and post it in the <code>#stuff-for-death</code> channel.</p>

--- a/test/fixtures/action_text/rich_texts.yml
+++ b/test/fixtures/action_text/rich_texts.yml
@@ -36,3 +36,12 @@ morkborg_footer:
       <p>Unless otherwise noted, the products presented here are independent productions by their respective authors/publishers and are not affiliated with Ockult Örtmästare Games or Stockholm Kartell. They are published under the MÖRK BORG Third Party License.</p>
       <p>MÖRK BORG is copyright Ockult Örtmästare Games and Stockholm Kartell.</p>
     </div>
+
+deathinspace_footer:
+  record: death_in_space (System)
+  name: footer
+  body: |
+    <div>
+      <p>DEATH IN SPACE is © Stockholm Kartell and/or other authors</p>
+      <p>Ex Libris Death in Space is an independent production by Ex Libris curators and is not affiliated with Stockholm Kartell. It is published under the DEATH IN SPACE Third Party License.</p>
+    </div>


### PR DESCRIPTION
hi John - I have several open questions wrt how best to handle the things I'm doing on this PR. Note: I am new to Tailwind.

- What is the best way to handle styling all h1, h2, and tw-button for the Death in Space site? I'm currently twiddling them directlhy in deathinspace.css, which seems incorrect for Tailwind (is it?).

- Is there any trick to getting tw-uppercase working? (Neither tw-uppercase or uppercase classes seemed to be working for me.) Currently I have explicit style= attributes set to accomplish this, which again seems Tailwind-incorrect.

- What's the best way to handle different About page html content? Right now I have a Death in Space specific erb that references a different field in en.yml, which feels a bit hacky.


